### PR TITLE
Add customization controls and improve canvas performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The site also includes a built-in fullscreen mode, a short set of on-page instru
 - Analyzes the sound using the [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API) and visualizes it on a `<canvas>`.
 - Dynamic background color and waveform that react to the incoming audio.
 - Optional fullscreen mode.
+- Adjustable color intensity and waveform style via on-page controls.
+- Optimized rendering with OffscreenCanvas and frame rate throttling.
 - Approximately 170 lines of plain JavaScript located in [`website/index.js`](website/index.js).
 
 ## Requirements

--- a/website/index.html
+++ b/website/index.html
@@ -19,6 +19,18 @@
     <button>Choose tab</button>
     <button class="fullscreen">Full screen</button>
     <button class="aboutbtn">About</button>
+    <label class="control">
+      Color intensity
+      <input id="darkMax" type="range" min="20" max="200" value="80" />
+    </label>
+    <label class="control">
+      Waveform style
+      <select id="waveStyle">
+        <option value="line" selected>Line</option>
+        <option value="circle">Circles</option>
+        <option value="both">Both</option>
+      </select>
+    </label>
 
     <div class="warning">
       <h2><span class="red">WARNING:</span> Flashing red lights</h2>

--- a/website/index.js
+++ b/website/index.js
@@ -1,15 +1,54 @@
-let [choosetab, fullscreen, aboutbtn] = Array.from(document.querySelectorAll("button"));
+let [choosetab, fullscreen, aboutbtn] = Array.from(
+  document.querySelectorAll("button")
+);
 let about = document.querySelector(".about");
 let closeabout = document.querySelector(".closeabout");
+let darkMaxInput = document.getElementById("darkMax");
+let waveStyleSelect = document.getElementById("waveStyle");
 let screenConstraints = { video: true, audio: true };
 let canvas = document.querySelector("canvas");
 let canvasCtx = canvas.getContext("2d");
+let offscreenCanvas = null;
+let drawCtx = canvasCtx;
+let darkMax = parseInt(darkMaxInput.value, 10);
+let waveStyle = waveStyleSelect.value;
+let rgb = [darkMax * 0.2, darkMax * 0.8, darkMax];
+let rgbDir = [true, true, true];
 
-const DARK_MAX = 80;
+if (window.OffscreenCanvas) {
+  offscreenCanvas = new OffscreenCanvas(canvas.width, canvas.height);
+  drawCtx = offscreenCanvas.getContext("2d");
+}
 
-setInterval(50, function () {
-  increment(rgb);
+darkMaxInput.addEventListener("input", (e) => {
+  darkMax = parseInt(e.target.value, 10);
 });
+
+waveStyleSelect.addEventListener("change", (e) => {
+  waveStyle = e.target.value;
+});
+
+const increment = function () {
+  const [r2, g2, b2] = rgb.map((color, i) => {
+    const up = rgbDir[i];
+    if (up) {
+      if (color === darkMax) {
+        rgbDir[i] = false;
+        return color - 1;
+      }
+      return color + 1;
+    } else {
+      if (color === 0) {
+        rgbDir[i] = true;
+        return color + 1;
+      }
+      return color - 1;
+    }
+  });
+  rgb = [r2, g2, b2];
+};
+
+setInterval(increment, 50);
 
 choosetab.addEventListener("click", () => {
   document.querySelector(".warning").classList.add("hide");
@@ -32,30 +71,18 @@ closeabout.addEventListener("click", () => {
 
 window.addEventListener("resize", () => {
   canvas = document.querySelector("canvas");
+  if (offscreenCanvas) {
+    offscreenCanvas.width = canvas.width;
+    offscreenCanvas.height = canvas.height;
+  }
 });
 
+const FRAME_INTERVAL = 1000 / 30;
+let lastFrame = 0;
+
 const startCapture = async function () {
-  let rgb = [DARK_MAX * 0.2, DARK_MAX * 0.8, DARK_MAX];
-  let rgbDir = [true, true, true];
-  const increment = function () {
-    const [r2, g2, b2] = rgb.map((color, i) => {
-      const up = rgbDir[i];
-      if (up) {
-        if (color === DARK_MAX) {
-          rgbDir[i] = false;
-          return color - 1;
-        }
-        return color + 1;
-      } else {
-        if (color === 0) {
-          rgbDir[i] = true;
-          return color + 1;
-        }
-        return color - 1;
-      }
-    });
-    rgb = [r2, g2, b2];
-  };
+  rgb = [darkMax * 0.2, darkMax * 0.8, darkMax];
+  rgbDir = [true, true, true];
 
   try {
     const stream = await navigator.mediaDevices.getDisplayMedia(
@@ -75,7 +102,13 @@ const startCapture = async function () {
     analyser.getByteTimeDomainData(dataArray);
 
     const draw = function () {
-      requestAnimationFrame(draw.bind(this));
+      requestAnimationFrame(draw);
+
+      const now = performance.now();
+      if (now - lastFrame < FRAME_INTERVAL) {
+        return;
+      }
+      lastFrame = now;
 
       if (Math.random() > 0.25) {
         increment();
@@ -83,84 +116,74 @@ const startCapture = async function () {
 
       analyser.getByteTimeDomainData(dataArray);
 
-      canvasCtx.fillStyle = "rgb(0, 0, 0)";
-      canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
+      drawCtx.fillStyle = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+      drawCtx.fillRect(0, 0, canvas.width, canvas.height);
 
-      canvasCtx.lineWidth = 4;
-      canvasCtx.strokeStyle = "rgb(255, 255, 255)";
+      drawCtx.lineWidth = 4;
+      drawCtx.strokeStyle = "rgb(255, 255, 255)";
 
-      canvasCtx.beginPath();
+      drawCtx.beginPath();
 
       let sliceWidth = (canvas.width * 1.0) / bufferLength;
-      let max = Math.max(...Array.from(dataArray)).toFixed(0);
-      let bgColor = (parseFloat(max) / 1.25).toFixed(0);
-      if (parseFloat(max) < 175) {
-        bgColor = (parseFloat(max) / 3).toFixed(0);
-      }
-      if (parseFloat(max) < 125) {
-        bgColor = (parseFloat(max) / 4).toFixed(0);
-      }
-      if (parseFloat(max) < 75) {
-        bgColor = (parseFloat(max) / 5).toFixed(0);
-      }
+      let max = Math.max(...Array.from(dataArray));
 
       let [r, g, b] = rgb;
-      let multiplier = 255 - DARK_MAX;
-      canvasCtx.fillStyle = `rgb(${r}, ${g}, ${b})`;
-      canvasCtx.fillRect(0, 0, canvas.width, canvas.height);
+      drawCtx.strokeStyle = `rgb(${r + 50}, ${g + 50}, ${b + 50})`;
 
-      let LINE_MAX = 255 - DARK_MAX;
-
-      canvasCtx.strokeStyle = `rgb(${r + 50}, ${g + 50}, ${b + 50})`;
-      if (max > 175) {
+      if (waveStyle !== "line" && max > 175) {
         [1, 2, 3, 4].forEach(function (n) {
-          canvasCtx.beginPath();
-          canvasCtx.arc(
+          drawCtx.beginPath();
+          drawCtx.arc(
             canvas.width / 2,
             canvas.height / 2,
-            (canvas.height / n) * (parseFloat(max) / 255),
+            (canvas.height / n) * (max / 255),
             0,
             2 * Math.PI
           );
-          canvasCtx.stroke();
+          drawCtx.stroke();
         });
       }
 
-      let x = 0;
-      for (let i = 0; i < bufferLength; i++) {
-        if (max > 200) {
-          increment();
-        }
-        if (max > 225) {
-          increment();
-          increment();
+      if (waveStyle !== "circle") {
+        let x = 0;
+        for (let i = 0; i < bufferLength; i++) {
+          if (max > 200) {
+            increment();
+          }
+          if (max > 225) {
+            increment();
+            increment();
+          }
+
+          let value = dataArray[i] * 1;
+          let v = value / 128.0;
+          let y = (v * canvas.height) / 2;
+
+          drawCtx.strokeStyle = `rgb(255, 255, 255)`;
+          if (max < 200) {
+            drawCtx.strokeStyle = `rgb(${r + 200}, ${g + 200}, ${b + 200})`;
+          }
+
+          if (i === 0) {
+            drawCtx.moveTo(x, y);
+          } else {
+            drawCtx.lineTo(x, y);
+          }
+
+          x += sliceWidth;
         }
 
-        let value = dataArray[i] * 1;
-        let v = value / 128.0;
-        let y = (v * canvas.height) / 2;
-        let c = value.toFixed(0);
-
-        canvasCtx.strokeStyle = `rgb(255, 255, 255)`;
-        if (max < 200) {
-          canvasCtx.strokeStyle = `rgb(${r + 200}, ${g + 200}, ${b + 200})`;
+        drawCtx.lineTo(canvas.width, canvas.height / 2);
+        drawCtx.lineWidth = 2;
+        if (max > 100) {
+          drawCtx.lineWidth = (max / 100) * 3;
         }
-
-        if (i === 0) {
-          canvasCtx.moveTo(x, y);
-        } else {
-          canvasCtx.lineTo(x, y);
-        }
-
-        x += sliceWidth;
+        drawCtx.stroke();
       }
 
-      canvasCtx.lineTo(canvas.width, canvas.height / 2);
-      canvasCtx.lineWidth = 2;
-      if (parseFloat(max) > 100) {
-        canvasCtx.lineWidth = (parseFloat(max) / 100) * 3;
+      if (offscreenCanvas) {
+        canvasCtx.drawImage(offscreenCanvas, 0, 0);
       }
-      canvasCtx.stroke();
     };
 
     draw();

--- a/website/style.css
+++ b/website/style.css
@@ -118,3 +118,14 @@ button:hover {
 .about.show {
   display: initial;
 }
+label.control {
+  position: absolute;
+  bottom: 60px;
+  left: 5px;
+  color: white;
+}
+
+label.control select,
+label.control input {
+  margin-left: 5px;
+}


### PR DESCRIPTION
## Summary
- fix global color increment timer setup
- expose DARK_MAX as a color intensity slider
- add waveform style dropdown
- throttle canvas drawing and use OffscreenCanvas when available
- mention new features in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68406a264b38832ea5c655c08d78e082