### PR TITLE
Add settings dialog for audio controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The site also includes a built-in fullscreen mode, a short set of on-page instru
 - Analyzes the sound using the [Web Audio API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API) and visualizes it on a `<canvas>`.
 - Dynamic background color and waveform that react to the incoming audio.
 - Optional fullscreen mode.
-- Adjustable color intensity and waveform style via on-page controls.
+ - Adjustable color intensity and waveform style via a settings dialog.
 - Optimized rendering with OffscreenCanvas and frame rate throttling.
 - Approximately 170 lines of plain JavaScript located in [`website/index.js`](website/index.js).
 

--- a/website/index.html
+++ b/website/index.html
@@ -16,21 +16,26 @@
   <body>
     <canvas width="2000" height="1500"></canvas>
 
-    <button>Choose tab</button>
+    <button class="choosetab">Choose tab</button>
     <button class="fullscreen">Full screen</button>
+    <button class="settingsbtn">Settings</button>
     <button class="aboutbtn">About</button>
-    <label class="control">
-      Color intensity
-      <input id="darkMax" type="range" min="20" max="200" value="80" />
-    </label>
-    <label class="control">
-      Waveform style
-      <select id="waveStyle">
-        <option value="line" selected>Line</option>
-        <option value="circle">Circles</option>
-        <option value="both">Both</option>
-      </select>
-    </label>
+
+    <div class="settings">
+      <a href="#" tabindex="0" class="closesettings">Close this</a>
+      <label class="control">
+        Color intensity
+        <input id="darkMax" type="range" min="20" max="200" value="80" />
+      </label>
+      <label class="control">
+        Waveform style
+        <select id="waveStyle">
+          <option value="line" selected>Line</option>
+          <option value="circle">Circles</option>
+          <option value="both">Both</option>
+        </select>
+      </label>
+    </div>
 
     <div class="warning">
       <h2><span class="red">WARNING:</span> Flashing red lights</h2>

--- a/website/index.js
+++ b/website/index.js
@@ -1,8 +1,11 @@
-let [choosetab, fullscreen, aboutbtn] = Array.from(
-  document.querySelectorAll("button")
-);
+let choosetab = document.querySelector(".choosetab");
+let fullscreen = document.querySelector(".fullscreen");
+let settingsbtn = document.querySelector(".settingsbtn");
+let aboutbtn = document.querySelector(".aboutbtn");
 let about = document.querySelector(".about");
 let closeabout = document.querySelector(".closeabout");
+let settings = document.querySelector(".settings");
+let closesettings = document.querySelector(".closesettings");
 let darkMaxInput = document.getElementById("darkMax");
 let waveStyleSelect = document.getElementById("waveStyle");
 let screenConstraints = { video: true, audio: true };
@@ -60,13 +63,22 @@ fullscreen.addEventListener("click", () => {
   canvas.requestFullscreen();
 });
 
-document.querySelector(".aboutbtn").addEventListener("click", () => {
+aboutbtn.addEventListener("click", () => {
   document.querySelector(".warning").classList.add("hide");
   about.classList.add("show");
 });
 
 closeabout.addEventListener("click", () => {
   about.classList.remove("show");
+});
+
+settingsbtn.addEventListener("click", () => {
+  document.querySelector(".warning").classList.add("hide");
+  settings.classList.add("show");
+});
+
+closesettings.addEventListener("click", () => {
+  settings.classList.remove("show");
 });
 
 window.addEventListener("resize", () => {

--- a/website/style.css
+++ b/website/style.css
@@ -46,6 +46,11 @@ button.aboutbtn {
   top: 5px;
   right: 5px;
 }
+button.settingsbtn {
+  bottom: initial;
+  top: 5px;
+  left: 5px;
+}
 
 p, h2 {
   color: #fff;
@@ -118,13 +123,31 @@ button:hover {
 .about.show {
   display: initial;
 }
-label.control {
-  position: absolute;
-  bottom: 60px;
-  left: 5px;
-  color: white;
-}
 
+.settings {
+  display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  padding: 20px;
+  color: black;
+  width: 100%;
+  max-width: 300px;
+}
+.settings.show {
+  display: initial;
+}
+.settings a {
+  float: right;
+  margin: 0 0 20px 20px;
+}
+.settings label {
+  display: block;
+  margin: 10px 0;
+  color: black;
+}
 label.control select,
 label.control input {
   margin-left: 5px;


### PR DESCRIPTION
## Summary
- add new Settings dialog
- hide intensity and waveform controls inside a modal
- add button and styles for the new dialog
- update index.js handlers
- mention settings dialog in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68406f941834832e8935953995215d15